### PR TITLE
Add PID new type wrapper

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,10 +1,11 @@
 ///! Trait for a hardware driver to implement
 pub use Error;
+use PID;
 
 pub trait Master {
     type Error: Into<::Error> + From<::Error>;
     fn send_wakeup(&mut self) -> Result<(), Self::Error>;
-    fn send_header(&mut self, pid: u8) -> Result<(), Self::Error>;
+    fn send_header(&mut self, pid: PID) -> Result<(), Self::Error>;
     fn read(&mut self, buf: &mut [u8]) -> Result<(), Self::Error>;
     fn write(&mut self, data: &[u8]) -> Result<(), Self::Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,8 @@ impl PID {
 /// Calculate the LIN checksum. It is defined as "The inverted eight bit sum with carry. Eight bit
 /// sum with carry is equivalent to sum all values and subtract 255 every time the sum is greater
 /// or equal to 256"
-pub fn checksum(pid: u8, data: &[u8]) -> u8 {
-    let sum = data.iter().fold(pid as u16, |sum, v| {
+pub fn checksum(pid: PID, data: &[u8]) -> u8 {
+    let sum = data.iter().fold(pid.0 as u16, |sum, v| {
         let sum = sum + *v as u16;
         if sum >= 256 {
             sum - 255
@@ -50,7 +50,7 @@ pub fn checksum(pid: u8, data: &[u8]) -> u8 {
 /// Calculate the classic checksum. It is defined as "Checksum calculation over the data bytes only
 /// is called classic checksum"
 pub fn classic_checksum(data: &[u8]) -> u8 {
-    checksum(0u8, data)
+    checksum(PID(0u8), data)
 }
 
 #[cfg(test)]
@@ -58,7 +58,7 @@ mod tests {
     use super::*;
 
     struct CheckSumTestData<'a> {
-        pid: u8,
+        pid: PID,
         data: &'a [u8],
         checksum: u8,
     }
@@ -66,17 +66,17 @@ mod tests {
     fn test_checksum() {
         let test_data = [
             CheckSumTestData {
-                pid: 0xDD,
+                pid: PID(0xDD),
                 data: &[0x01],
                 checksum: 0x21,
             },
             CheckSumTestData {
-                pid: 0x4A,
+                pid: PID(0x4A),
                 data: &[0x55, 0x93, 0xE5],
                 checksum: 0xE6,
             },
             CheckSumTestData {
-                pid: 0xBF,
+                pid: PID(0xBF),
                 data: &[0x40, 0xFF],
                 checksum: 0x00,
             },


### PR DESCRIPTION
By only allowing the PID type in the API we avoid passing illegal identifiers.