### PR TITLE
Make crate no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 pub mod driver;
 pub mod master;
 


### PR DESCRIPTION
This crate currently doesn't use the standard library of Rust.  This
makes it possible to use it in embedded contexts.  To keep it that way
we mark it no_std.