### PR TITLE
Add decode function to Frame

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,12 @@ version = "0.1.0"
 authors = ["Raphael Nestler <raphael.nestler@sensirion.com>"]
 
 [dependencies]
+bitfield = "^0.13"
+
+[dependencies.num-traits]
+version = "^0.2"
+default-features = false
+
+[dependencies.byteorder]
+version = "^1.0"
+default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
 #![no_std]
+extern crate bitfield;
+extern crate byteorder;
+extern crate num_traits;
+
 pub mod driver;
 pub mod master;
 


### PR DESCRIPTION
This allows us to extract data from a LIN frame as defined in the .ldf
file using offset and length of a signal.