### PR TITLE
Fix cargo toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Raphael Nestler <raphael.nestler@sensirion.com>"]
 description = "LIN bus driver traits and protocol implementation"
 readme = "README.md"
-keywords = ["LIN", "Local Interconnect Network"]
+keywords = ["LIN", "local", "interconnect", "network"]
 categories = ["no-std", "hardware-support"]
 license = "BSD-3-Clause"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 keywords = ["LIN", "local", "interconnect", "network"]
 categories = ["no-std", "hardware-support"]
 license = "BSD-3-Clause"
+repository = "https://github.com/Sensirion/lin-bus-rs"
 
 [dependencies]
 bitfield = "^0.13"


### PR DESCRIPTION
During `cargo publish` I noticed some errors in the meta-data which didn't allow me to publish. I'll fast forward merge this, since I actually published this version.