### PR TITLE
Derive Copy, Clone, PartialEq and Eq for Error type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project follows [semantic versioning](https://semver.org/).
 
 ## [Unreleased]
 
+ * changed: Derive Copy, Clone, PartialEq and Eq for Error enum
+   ([#11](https://github.com/Sensirion/lin-bus-rs/pull/11))
+
 ## 0.1.0 (2018-06-25)
 
  * First crates.io release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+This project follows [semantic versioning](https://semver.org/).
+
+## [Unreleased]
+
+## 0.1.0 (2018-06-25)
+
+ * First crates.io release
+
+[Unreleased]: https://github.com/Sensirion/lin-bus-rs/compare/v0.1.0...HEAD

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub mod master;
 
 pub use master::Master;
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Error {
     Timeout,
     PhysicalBus,


### PR DESCRIPTION
This allows us to copy and compare the Error enum.