### PR TITLE
Update to Rust 2018 syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:latest
+      - image: rust:1.31
     steps:
       - checkout
-      - run: rustup component add rustfmt-preview
+      - run: rustup component add rustfmt
       - run: cargo build
       - run: cargo test
-      - run: cargo fmt -- --write-mode=diff
+      - run: cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["LIN", "local", "interconnect", "network"]
 categories = ["no-std", "hardware-support"]
 license = "BSD-3-Clause"
 repository = "https://github.com/Sensirion/lin-bus-rs"
+edition = "2018"
 
 [dependencies]
 bitfield = "^0.13"

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,9 +1,9 @@
 ///! Trait for a hardware driver to implement
-pub use Error;
-use PID;
+pub use crate::Error;
+use crate::PID;
 
 pub trait Master {
-    type Error: Into<::Error> + From<::Error>;
+    type Error: Into<crate::Error> + From<crate::Error>;
     fn send_wakeup(&mut self) -> Result<(), Self::Error>;
     fn send_header(&mut self, pid: PID) -> Result<(), Self::Error>;
     fn read(&mut self, buf: &mut [u8]) -> Result<(), Self::Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ extern crate num_traits;
 pub mod driver;
 pub mod master;
 
-pub use master::Master;
+pub use crate::master::Master;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Error {

--- a/src/master.rs
+++ b/src/master.rs
@@ -1,11 +1,11 @@
+///! LIN bus master implementation
+use crate::checksum;
+use crate::driver;
+use crate::PID;
 use bitfield::BitRange;
 use byteorder::{ByteOrder, LittleEndian};
-///! LIN bus master implementation
-use checksum;
 use core::mem::size_of;
-use driver;
 use num_traits::{PrimInt, Unsigned};
-use PID;
 
 pub trait Master {
     type Error;


### PR DESCRIPTION
Just ran `cargo fix --edition` and `cargo fmt`.