### PR TITLE
Classic checksum on special frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ This project follows [semantic versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0] (2019-04-18)
+
  * changed: Use Rust 2018 edition syntax
    ([#13](https://github.com/Sensirion/lin-bus-rs/pull/13))
+ * changed: Use classic checksum on special frames. Adds
+   `PID::uses_classic_checksum` and `PID::get_id`.
 
 ## [0.1.1] (2018-07-04)
 
@@ -16,5 +20,6 @@ This project follows [semantic versioning](https://semver.org/).
 
  * First crates.io release
 
-[Unreleased]: https://github.com/Sensirion/lin-bus-rs/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/Sensirion/lin-bus-rs/compare/v0.2.0...HEAD
+[0.1.2]: https://github.com/Sensirion/lin-bus-rs/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/Sensirion/lin-bus-rs/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lin-bus"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Raphael Nestler <raphael.nestler@sensirion.com>"]
 description = "LIN bus driver traits and protocol implementation"
 readme = "README.md"


### PR DESCRIPTION
LIN Standard mandates the old LIN V1.3 classic checksum for diagnostic
and special frames with IDs >= 60 (0x3c).

* Add `uses_classic_checksum` method to trait PID
* Add unit tests for the classic checksum and `uses_classic_checksum`
* Improve documentation

Prepare for release 0.2.0