### PR TITLE
Fix decoding of frame which uses last bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project follows [semantic versioning](https://semver.org/).
 
 ## [Unreleased]
 
+ * fixed: Decoding of frame which uses last bit
+   ([#15](https://github.com/Sensirion/lin-bus-rs/pull/15))
+
 ## [0.2.0] (2019-04-18)
 
  * changed: Use Rust 2018 edition syntax

--- a/src/master.rs
+++ b/src/master.rs
@@ -53,7 +53,7 @@ impl Frame {
         u64: BitRange<T>,
     {
         assert!(
-            (offset + length) < self.data_length * 8,
+            (offset + length) <= self.data_length * 8,
             "Not enough data available"
         );
         assert!(length <= size_of::<T>() * 8, "Output type not big enough");

--- a/src/master.rs
+++ b/src/master.rs
@@ -166,4 +166,10 @@ mod tests {
             assert_eq!(d.0.decode::<u16>(20, 11), d.1[2]);
         }
     }
+
+    #[test]
+    fn test_data_decode_all_bits() {
+        let frame = Frame::from_data(PID(0), &[0x55, 0xDD]);
+        assert_eq!(frame.decode::<u16>(0, 16), 0xdd55);
+    }
 }


### PR DESCRIPTION
Previously we couldn't decode frames which used the last bit.