### PR TITLE
Declare PID functions as const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project follows [semantic versioning](https://semver.org/).
 
 ## [Unreleased]
 
+ * changed: Declare some functions as `const fn`
+   ([#15](https://github.com/Sensirion/lin-bus-rs/pull/19))
+
 ## [0.2.1] (2019-05-06)
 
  * fixed: Decoding of frame which uses last bit

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,18 +29,18 @@ impl PID {
     }
 
     /// Return the contained PID
-    pub fn get(self) -> u8 {
+    pub const fn get(self) -> u8 {
         self.0
     }
 
     /// Return the contained ID
-    pub fn get_id(self) -> u8 {
+    pub const fn get_id(self) -> u8 {
         self.0 & 0b0011_1111
     }
 
     /// Return if the associated frame uses the classic checksum (diagnostic IDs 60 and 61 or
     /// special use IDs 62, 63)
-    pub fn uses_classic_checksum(self) -> bool {
+    pub const fn uses_classic_checksum(self) -> bool {
         self.get_id() >= 60
     }
 }


### PR DESCRIPTION
They do very simple operations and extractions which can also be done on
constants. The only thing not possible is the `from_id` because it
contains an assert.