### PR TITLE
Bump Rust version to fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.33
+      - image: rust:1.34
     steps:
       - checkout
       - run: rustup component add rustfmt


### PR DESCRIPTION
A dependency apparently bumped their minimally supported Rust version.

Check the following:

 - [na] Breaking changes marked in commit message
 - [na] Changelog updated
 - [na] Tests added
