### PR TITLE
Make more functions `const fn`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.34
+      - image: rust:1.57
     steps:
       - checkout
       - run: rustup component add rustfmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project follows [semantic versioning](https://semver.org/).
 
+## [0.4.0] (Unreleased)
+
+ * changed: `PID::new`, `PID::from_id`, `PCI::new_sf` and `PCI::get_type` are
+   now `const fn`s. ([#33](https://github.com/Sensirion/lin-bus-rs/pull/33))
+ * breaking: Minimal required Rust version changed to 1.57.0
+
 ## [0.3.2] (2021-10-28)
 
  * added: `PID::new` to construct PID's with a known value

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -13,9 +13,9 @@ pub struct PID(u8);
 
 impl PID {
     /// Creates a new PID object with given PID
-    pub fn new(pid: u8) -> PID {
+    pub const fn new(pid: u8) -> PID {
         // check that the given PID has valid parity bits
-        let correct_pid = PID::from_id_const(pid & 0b0011_1111);
+        let correct_pid = PID::from_id(pid & 0b0011_1111);
         assert!(correct_pid.0 == pid, "Invalid PID");
         correct_pid
     }
@@ -23,13 +23,8 @@ impl PID {
     /// Calculate the PID from an ID.
     /// P0 = ID0 ⊕ ID1 ⊕ ID2 ⊕ ID4
     /// P1 = ¬(ID1 ⊕ ID3 ⊕ ID4 ⊕ ID5)
-    pub fn from_id(id: u8) -> PID {
+    pub const fn from_id(id: u8) -> PID {
         assert!(id < 64, "ID must be less than 64");
-        PID::from_id_const(id)
-    }
-
-    /// Const implementation of `from_id` which doesn't validate id
-    const fn from_id_const(id: u8) -> PID {
         // count parity bits and check if they are even odd
         let p0 = (id & 0b1_0111).count_ones() as u8 & 0b1;
         let p1 = ((id & 0b11_1010).count_ones() as u8 + 1) & 0b1;
@@ -170,13 +165,13 @@ pub mod transport {
 
     impl PCI {
         /// Create a `PCI` with type `PCIType::SF` and the given length
-        pub fn new_sf(length: u8) -> PCI {
+        pub const fn new_sf(length: u8) -> PCI {
             assert!(length <= 6, "Maximum length for single frame is 6");
             PCI(length)
         }
 
         /// Get the `PCIType` of the PCI
-        pub fn get_type(self) -> PCIType {
+        pub const fn get_type(self) -> PCIType {
             match self.0 >> 4 {
                 0 => PCIType::SF,
                 1 => PCIType::FF,
@@ -226,8 +221,8 @@ pub mod diagnostic {
     pub const MASTER_REQUEST_FRAME_ID: u8 = 0x3C;
     pub const SLAVE_RESPONSE_FRAME_ID: u8 = 0x3D;
 
-    pub const MASTER_REQUEST_FRAME_PID: PID = PID::from_id_const(0x3C);
-    pub const SLAVE_RESPONSE_FRAME_PID: PID = PID::from_id_const(0x3D);
+    pub const MASTER_REQUEST_FRAME_PID: PID = PID::from_id(0x3C);
+    pub const SLAVE_RESPONSE_FRAME_PID: PID = PID::from_id(0x3D);
 
     pub const READ_BY_IDENTIFIER_SID: SID = SID(0xB2);
 


### PR DESCRIPTION
Check the following:

 - [x] Breaking changes marked in commit message
 - [x] Changelog updated
 - [na] Tests added

Since Rust 1.57.0 const fn can contain simple asserts.
See https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#panic-in-const-contexts